### PR TITLE
Enable exporting the reply sizes via an histogram

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,7 @@ geo-bench
 
 # coverage
 coverage.txt
+
+# csv file
+*.csv
+

--- a/Readme.md
+++ b/Readme.md
@@ -105,7 +105,6 @@ $ curl -k --user "elastic:password" -X GET "https://localhost:9200/geo/_count?pr
 
 # check the memory usage of that index
 $ curl -k --user "elastic:password" -X GET "https://localhost:9200/geo/_stats?pretty" -H 'Content-Type: application/json'
-
 ```
 
 #### Query data in ElasticSearch


### PR DESCRIPTION
Introduce the --reply-histogram-csv option in the query tool to allow exporting an histogram of reply sizes. 
Sample output:
```
reply_size,count
0,21
1,3072
2,501
3,24
4,20
5,6
6,2
7,3
8,2
9,3
10,2
11,4
12,3
13,1
14,1
15,1
16,4
17,0
18,1
19,0
20,0
21,1
22,0
23,0
24,0
25,0
26,1
27,0

```