### PR TITLE
chore: add Dockerfile and publish to redis/geo-bench

### DIFF
--- a/.github/workflows/docker-publish-master.yml
+++ b/.github/workflows/docker-publish-master.yml
@@ -1,0 +1,61 @@
+name: Docker Publish - Latest
+
+on:
+  push:
+    branches: [main]
+    paths-ignore:
+      - '**.md'
+
+env:
+  REGISTRY: docker.io
+  IMAGE_NAME: redis/geo-bench
+
+jobs:
+  docker-publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Log in to Docker Hub
+      uses: docker/login-action@v3
+      with:
+        registry: ${{ env.REGISTRY }}
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+
+    - name: Extract metadata for Docker
+      id: docker_meta
+      uses: docker/metadata-action@v5
+      with:
+        images: ${{ env.IMAGE_NAME }}
+        tags: |
+          type=raw,value=latest
+          type=raw,value=main-{{sha}}
+
+    - name: Build and push Docker image
+      uses: docker/build-push-action@v5
+      with:
+        context: .
+        platforms: linux/amd64,linux/arm64
+        push: true
+        tags: ${{ steps.docker_meta.outputs.tags }}
+        labels: ${{ steps.docker_meta.outputs.labels }}
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
+
+    - name: Generate summary
+      run: |
+        echo "## 🐳 Docker Image Published" >> $GITHUB_STEP_SUMMARY
+        echo "**Repository:** \`${{ env.IMAGE_NAME }}\`" >> $GITHUB_STEP_SUMMARY
+        echo "**Tags:** ${{ steps.docker_meta.outputs.tags }}" >> $GITHUB_STEP_SUMMARY
+        echo "🔗 [View on Docker Hub](https://hub.docker.com/r/${{ env.IMAGE_NAME }})" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/docker-publish-release.yml
+++ b/.github/workflows/docker-publish-release.yml
@@ -1,0 +1,62 @@
+name: Docker Publish - Release
+
+on:
+  release:
+    types: [published]
+
+env:
+  REGISTRY: docker.io
+  IMAGE_NAME: redis/geo-bench
+
+jobs:
+  docker-publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Log in to Docker Hub
+      uses: docker/login-action@v3
+      with:
+        registry: ${{ env.REGISTRY }}
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+
+    - name: Extract metadata for Docker
+      id: docker_meta
+      uses: docker/metadata-action@v5
+      with:
+        images: ${{ env.IMAGE_NAME }}
+        tags: |
+          type=ref,event=tag
+          type=semver,pattern={{version}}
+          type=semver,pattern={{major}}.{{minor}}
+          type=raw,value=latest
+
+    - name: Build and push Docker image
+      uses: docker/build-push-action@v5
+      with:
+        context: .
+        platforms: linux/amd64,linux/arm64
+        push: true
+        tags: ${{ steps.docker_meta.outputs.tags }}
+        labels: ${{ steps.docker_meta.outputs.labels }}
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
+
+    - name: Generate summary
+      run: |
+        echo "## 🚀 Docker Release Published" >> $GITHUB_STEP_SUMMARY
+        echo "**Repository:** \`${{ env.IMAGE_NAME }}\`" >> $GITHUB_STEP_SUMMARY
+        echo "**Release:** \`${{ github.ref_name }}\`" >> $GITHUB_STEP_SUMMARY
+        echo "**Tags:** ${{ steps.docker_meta.outputs.tags }}" >> $GITHUB_STEP_SUMMARY
+        echo "🔗 [View on Docker Hub](https://hub.docker.com/r/${{ env.IMAGE_NAME }})" >> $GITHUB_STEP_SUMMARY

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,37 @@
+FROM golang:1.21-alpine AS builder
+
+RUN apk add --no-cache git ca-certificates
+
+WORKDIR /app
+
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+
+ARG GIT_SHA
+ARG GIT_DIRTY
+RUN GIT_SHA=${GIT_SHA:-$(git rev-parse HEAD 2>/dev/null || echo "unknown")} && \
+    GIT_DIRTY=${GIT_DIRTY:-$(git diff --no-ext-diff 2>/dev/null | wc -l || echo "0")} && \
+    CGO_ENABLED=0 GOOS=linux GO111MODULE=on go build \
+        -ldflags="-w -s -X 'main.GitSHA1=${GIT_SHA}' -X 'main.GitDirty=${GIT_DIRTY}'" \
+        -o geo-bench .
+
+FROM alpine:3.19
+
+RUN apk --no-cache add ca-certificates
+
+RUN addgroup -g 1001 -S appgroup && \
+    adduser -u 1001 -S appuser -G appgroup
+
+WORKDIR /app
+
+COPY --from=builder /app/geo-bench .
+
+RUN chown appuser:appgroup /app/geo-bench && \
+    chmod +x /app/geo-bench
+
+USER appuser
+
+ENTRYPOINT ["/app/geo-bench"]
+CMD ["--help"]


### PR DESCRIPTION
## Summary

- Adds a multi-stage `Dockerfile` (golang:1.21-alpine builder → alpine:3.19 runtime, non-root user)
- Adds `docker-publish-master.yml`: builds and pushes `redis/geo-bench:latest` and `redis/geo-bench:main-<sha>` on every push to `main`
- Adds `docker-publish-release.yml`: builds and pushes versioned tags on GitHub releases
- Both workflows build multi-arch images (linux/amd64, linux/arm64)

## Why

Part of the redis-performance org Docker image standardization. Enables `docker run redis/geo-bench --help` without requiring a Go environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)