### PR TITLE
chore: bump GitHub Actions to node24-compatible versions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,8 +19,8 @@ jobs:
         goos: [linux, darwin, windows]
         goarch: [amd64, arm64]
     steps:
-      - uses: actions/checkout@v3
-      - uses: wangyoucao577/go-release-action@v1.36
+      - uses: actions/checkout@v6
+      - uses: wangyoucao577/go-release-action@v1.55
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           goos: ${{ matrix.goos }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,12 +28,12 @@ jobs:
 
     steps:
       - name: Set up ${{ matrix.go-version }}
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v6
         with:
           go-version: ${{ matrix.go-version }}
 
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
 
       - name: Test
         run: make flowtest


### PR DESCRIPTION
GitHub is deprecating the **node20** runner for GitHub Actions on **June 16, 2026**. Workflow steps using node20-based action versions will fail after this date.

This PR bumps all affected actions to their latest node24-compatible versions.

> Reviewed by 3 independent agents (opus/sonnet/haiku) before opening.