### PR TITLE
fix: update Go version matrix to 1.20+ (rueidis requires Go 1.20)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [1.18.x, 1.19.x]
+        go-version: [1.20.x, 1.21.x]
 
     services:
       redis:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module filipecosta90/geo-bench
 
-go 1.19
+go 1.20
 
 require (
 	github.com/HdrHistogram/hdrhistogram-go v1.1.2


### PR DESCRIPTION
## Problem

The CI workflow tested against Go 1.18.x and 1.19.x, but the project's dependency `github.com/filipecosta90/rueidis@v0.0.0-20230731125225-704e76e542e7` requires Go 1.20. It uses `unsafe.String`, `unsafe.SliceData`, and `unsafe.StringData`, which are only available in Go 1.20+. This caused CI to fail with:

```
undefined: unsafe.String
undefined: unsafe.SliceData
undefined: unsafe.StringData
note: module requires Go 1.20
```

## Fix

Drop Go 1.18.x and 1.19.x from the test matrix and replace them with 1.20.x and 1.21.x.

## Changes

- `.github/workflows/test.yml`: `go-version: [1.18.x, 1.19.x]` → `go-version: [1.20.x, 1.21.x]`