### PR TITLE
fix: pin Redis service container image to 8.6

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
 
     services:
       redis:
-        image: redis
+        image: redis:8.6
         options: >-
           --health-cmd "redis-cli ping" --health-interval 10s --health-timeout 5s --health-retries 5
         ports:


### PR DESCRIPTION
Updates all Redis image references to redis:8.6 per org standard (8.6 minimum).

Changes:
- `.github/workflows/test.yml`: untagged `image: redis` → `image: redis:8.6`